### PR TITLE
Cast interval to VARCHAR

### DIFF
--- a/DuckDB.pq
+++ b/DuckDB.pq
@@ -182,7 +182,7 @@ shared DuckDB.Contents = (database as text, optional motherduck_token as text, o
                     else if dataType = DUCKDB_BLOB then
                         ODBC[SQL_TYPE][BINARY]
                     else if dataType = DUCKDB_INTERVAL then
-                        ODBC[SQL_TYPE][INTERVAL]
+                        ODBC[SQL_TYPE][VARCHAR]
                     else if dataType = DUCKDB_UTINYINT then
                         ODBC[SQL_C][UTINYINT]
                     else if dataType = DUCKDB_USMALLINT then


### PR DESCRIPTION
Fixes #7 

<img width="778" alt="image" src="https://github.com/MotherDuck-Open-Source/duckdb-power-query-connector/assets/4041805/87adb0b4-37bd-4fdf-b2bc-0e4a73151712">

<img width="665" alt="image" src="https://github.com/MotherDuck-Open-Source/duckdb-power-query-connector/assets/4041805/56781772-cd68-4672-83db-fb0d2d2a296a">

Needs fix in `duckdb` (see https://github.com/duckdb/duckdb/pull/12080)