### PR TITLE
Don't advertise ODBC `{fn}` string-function escapes

### DIFF
--- a/DuckDB.pq
+++ b/DuckDB.pq
@@ -100,7 +100,13 @@ shared DuckDB.Contents = (
                     // The values below are required for the SQL Native Client ODBC driver, but might
                     // not be required for your data source.
                     SQL_SQL92_PREDICATES = ODBC[SQL_SP][All],
-                    SQL_AGGREGATE_FUNCTIONS = ODBC[SQL_AF][All]
+                    SQL_AGGREGATE_FUNCTIONS = ODBC[SQL_AF][All],
+                    // The DuckDB ODBC driver does not translate ODBC {fn ...} scalar-function
+                    // escapes, so advertise none. Otherwise the engine folds Text.Contains to
+                    // {fn LOCATE(...)}, which reaches DuckDB verbatim and fails to parse.
+                    // With no escapes advertised the engine folds to LIKE
+                    // or evaluates client-side.
+                    SQL_STRING_FUNCTIONS = 0
                 ]
         ),
         // SQLGetTypeInfo can be specified in two ways:


### PR DESCRIPTION
The DuckDB ODBC driver does not translate ODBC scalar-function escapes, so `{fn LOCATE(...)}` - which the engine emits when folding `Text.Contains` - reaches DuckDB verbatim and fails to parse. Folding then fails for simple text filters.

Override `SQL_STRING_FUNCTIONS` to 0 so the engine never emits `{fn}` string escapes; `Text.Contains` folds to `LIKE` (supported) or runs client-side. Confirmed this works in PowerBI once [the ODBC PR](https://github.com/duckdb/duckdb-odbc/pull/478) is merged as well. This is not blocked by the ODBC fix though.